### PR TITLE
un-shat 35 auto

### DIFF
--- a/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/caseless_rifle.yml
+++ b/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/caseless_rifle.yml
@@ -7,7 +7,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 16 #Slightly higher than normal pistol damage
+        Piercing: 21
 
 - type: entity
   id: BulletCaselessRiflePractice

--- a/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/pistol.yml
+++ b/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/pistol.yml
@@ -7,7 +7,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 10 #Plink Plink
+        Piercing: 21
 
 - type: entity
   id: BulletPistolPractice


### PR DESCRIPTION
35 auto is now back to 21 damage
25 caseless is now also 21 damage
##Why
in #15 these calibers were nerfed pretty much into the ground in order to make rifles shine more, even though this was already achieved by increasing rifle caliber damage to 30, so reducing 35 auto damage to FUCKING 10 was way undertuned

keep in mind that pistol mags contain 10 bullets so you would need to dump an entire magazine onto an unarmored target to just crit them
and wearing even the DSM armor vest or hardsuit will reduce the damage to 6