### PR TITLE
bombastic trade goods

### DIFF
--- a/_Crescent/Entities/Objects/Misc/trade.yml
+++ b/_Crescent/Entities/Objects/Misc/trade.yml
@@ -64,7 +64,18 @@
     - state: icon
   - type: StaticPrice
     price: 500
-
+  - type: Destructible
+    thresholds:
+      - trigger:
+          !type:DamageTrigger
+          damage: 300
+        behaviors:
+          - !type:DoActsBehavior
+            acts: [ "Destruction" ]
+              - type: Explosive
+             explosionType: Default
+             totalIntensity: 120 
+ 
 - type: entity
   parent: BaseTradeItem
   id: TradeGoodAmmo
@@ -78,24 +89,17 @@
   - type: StaticPrice
     price: 400
   - type: Destructible
+  - type: Destructible
     thresholds:
       - trigger:
           !type:DamageTrigger
-          damage: 60
+          damage: 300
         behaviors:
-          - !type:SpawnEntitiesBehavior
-            spawn:
-              MagazineVulcan:
-                min: 0
-                max: 1
-              CartridgeShellArmorPiercing:
-                min: 0
-                max: 1
-              MagazineNeedler:
-                min: 1
-                max: 1
           - !type:DoActsBehavior
             acts: [ "Destruction" ]
+              - type: Explosive
+             explosionType: Default
+             totalIntensity: 120 
 
 - type: entity
   parent: BaseTradeItem
@@ -217,16 +221,14 @@
     thresholds:
       - trigger:
           !type:DamageTrigger
-          damage: 60
+          damage: 300
         behaviors:
-          - !type:SpawnEntitiesBehavior
-            spawn:
-              ScrapPlasma:
-                min: 2
-                max: 4
           - !type:DoActsBehavior
             acts: [ "Destruction" ]
-
+              - type: Explosive
+             explosionType: Default
+             totalIntensity: 120 
+             
 - type: entity
   parent: BaseTradeItem
   id: TradeGoodWine
@@ -250,6 +252,17 @@
         - CrateMask #this is so they can go under plastic flaps
         layer:
         - MachineLayer
+  - type: Destructible
+    thresholds:
+      - trigger:
+          !type:DamageTrigger
+          damage: 300
+        behaviors:
+          - !type:DoActsBehavior
+            acts: [ "Destruction" ]
+              - type: Explosive
+             explosionType: Default
+             totalIntensity: 120 
 
 - type: entity
   parent: BaseTradeItem
@@ -266,18 +279,13 @@
     thresholds:
       - trigger:
           !type:DamageTrigger
-          damage: 60
+          damage: 300
         behaviors:
-          - !type:SpawnEntitiesBehavior
-            spawn:
-              CrashAutoinjector:
-                min: 1
-                max: 2
-              ExileAutoinjector:
-                min: 0
-                max: 1
           - !type:DoActsBehavior
             acts: [ "Destruction" ]
+              - type: Explosive
+             explosionType: Default
+             totalIntensity: 120 
 
 - type: entity
   parent: BaseTradeItem


### PR DESCRIPTION
currently there's no reason to ferry flour over vodka or scrap over plasma, this puts requirement of security and actual usage of secure cargo folds instead of adding lattices around to maximize the money fountain output

specifically renders alcohol, plasma, ammo and chems volatile with 300 hp buffer making them naturally happy to cook off 