### PR TITLE
Vibro buff

### DIFF
--- a/_Crescent/Entities/Clothing/SRM/sword.yml
+++ b/_Crescent/Entities/Clothing/SRM/sword.yml
@@ -2,7 +2,7 @@
   name: hunter's vibrokhopesh
   parent: BaseItem
   id: SRMKhopesh
-  description: A ceremonial weapon belonging to the Hunters.
+  description: A ceremonial weapon once belonging to the Hunters.
   components:
   - type: Sharp
   - type: Sprite
@@ -10,7 +10,7 @@
     state: icon
   - type: MeleeWeapon
     wideAnimationRotation: -135
-    attackRate: 1.5
+    attackRate: 1.25
     damage:
       types:
         Slash: 33 #cmon, it has to be at least BETTER than the rest.
@@ -18,8 +18,8 @@
         path: /Audio/Weapons/bladeslice.ogg
   - type: Reflect
     enabled: true
-    reflectProb: .75
-    spread: 75
+    reflectProb: .85
+    spread: 60
   - type: Item
     size: Normal
     sprite: _Crescent/Objects/Weapons/vibrokhopesh.rsi


### PR DESCRIPTION
1. NCWL has both Hades and conscript which, as seen today, can be made in STUPID numbers for their general populace. And are better than anything DSM can output.

2. The Vibro was gutted when they made it two handed, a reasonable change. But considering how DSM armor and weapons hold up against NCWL, it is reasonable that the Vibro gets a buff to compensate.

The alternative is giving DSM a heavier suit to stand against the HADES. Unfortunately, nobody has bothered to sprite or do this. So I'm buffing Vibro instead.