### PR TITLE
Vibro buff baby

### DIFF
--- a/_Crescent/Entities/Clothing/SRM/sword.yml
+++ b/_Crescent/Entities/Clothing/SRM/sword.yml
@@ -2,7 +2,7 @@
   name: hunter's vibrokhopesh
   parent: BaseItem
   id: SRMKhopesh
-  description: A ceremonial weapon belonging to the Hunters.
+  description: A ceremonial weapon once belonging to the Hunters.
   components:
   - type: Sharp
   - type: Sprite
@@ -10,7 +10,7 @@
     state: icon
   - type: MeleeWeapon
     wideAnimationRotation: -135
-    attackRate: 1.5
+    attackRate: 1.25
     damage:
       types:
         Slash: 33 #cmon, it has to be at least BETTER than the rest.
@@ -18,8 +18,8 @@
         path: /Audio/Weapons/bladeslice.ogg
   - type: Reflect
     enabled: true
-    reflectProb: .75
-    spread: 75
+    reflectProb: .85
+    spread: 60
   - type: Item
     size: Normal
     sprite: _Crescent/Objects/Weapons/vibrokhopesh.rsi

--- a/_Crescent/Entities/Clothing/SRM/sword.yml
+++ b/_Crescent/Entities/Clothing/SRM/sword.yml
@@ -13,7 +13,7 @@
     attackRate: 1.25
     damage:
       types:
-        Slash: 33 #cmon, it has to be at least BETTER than the rest.
+        Slash: 43 #cmon, it has to be at least BETTER than the rest.
     soundHit:
         path: /Audio/Weapons/bladeslice.ogg
   - type: Reflect


### PR DESCRIPTION
Big boy vibro can't hold a fucking candle to NCWL rn. This changes that.

WAHHH WAHHH VIBRO WOULD BE OP IF YOU DID THIS WAHHH WAHHH 

NCWL is gonna spam conscripts anyways LOL. and vibro can't deflect conscript LOL. This evens the odds and makes DSM capable of boarding without eating .50 up the nose the second they board a sasha with 8 APCs strapped to the shield gen.