### PR TITLE
Draugr and Thukker suit buff

### DIFF
--- a/_Crescent/Entities/Clothing/FourFamilies/OuterClothing/armor.yml
+++ b/_Crescent/Entities/Clothing/FourFamilies/OuterClothing/armor.yml
@@ -16,16 +16,16 @@
   - type: ExplosionResistance
     damageCoefficient: 0.6
   - type: DegradeableArmor
-    armorMaxHealth: 750
+    armorMaxHealth: 1000
     armorType: Metallic
     armorRepair: SteelPlate
     initialModifiers:
       flatReductions:
-        Blunt: 15
-        Slash: 15
-        Piercing: 45
-        Heat: 15
-        Caustic: 25
+        Blunt: 30
+        Slash: 30
+        Piercing: 50
+        Heat: 10
+        Caustic: 20
   - type: ClothingSpeedModifier
     walkModifier: 0.80
     sprintModifier: 0.85
@@ -125,7 +125,7 @@
       flatReductions:
         Blunt: 10
         Slash: 10
-        Piercing: 10
+        Piercing: 15
         Heat: 10
         Caustic: 25
   - type: ClothingSpeedModifier


### PR DESCRIPTION
Thukker Hardsuit had less proc than even the base SHI HEV. Buffed it to a very reasonable 15.

Al'Seik hardsuit was incapable of entering melee combat previously as it's health was too low and its proc was too low as well. Meaning one of the main gimmicks of TAP couldn't be used without copious amounts of stimulants just to get close.